### PR TITLE
Remove warning for case 107517

### DIFF
--- a/cpeval2
+++ b/cpeval2
@@ -272,12 +272,10 @@ sub print_news_plesk {
 }
 
 sub print_news_ensim {
-    print q{   !! ENSIM BLOCKERS !!
-
-Case 107517: Check to see if this case is resolved and published to _DEVEL or _PUBLIC, if not, you may not be able to use Transfer Tool or cpmig.sh and must perform a manual migration.
-    };
-
-    sleep 3;
+#    print q{   !! ENSIM BLOCKERS !!
+#    };
+#
+#    sleep 3;
 }
 
 sub print_news_da {


### PR DESCRIPTION
Case 107517: This got fixed a little while ago, and is now in both
PUBLIC and DEVEL builds, so remove the warning about it.