### PR TITLE
Add auto userdomains updater, various additional fixes

### DIFF
--- a/cpeval2
+++ b/cpeval2
@@ -1,69 +1,144 @@
 #!/usr/bin/perl
 
+my $pod_data = << 'END_POD';
+=head1 NAME
+
+cpeval2
+
+=head1 DESCRIPTION
+
+Checks account and configuration information on third-party (non-cPanel) source and cPanel destination servers, performs a configuration comparison, and outputs a form ready for sending to a customer to explain any required or recommended changes.
+
+=head1 SYNOPSIS
+
+=for comment
+Keep the usage() sub in sync with the options here.
+=end comment
+
+=over
+
+=item Mode 1:
+
+B<cpeval2>
+
+=back
+
+=over
+
+=item Mode 2:
+
+B<cpeval2> S<I<INPUTFILE>>
+
+B<cpeval2> S<B<--es> I<INPUTFILE>>
+
+=back
+
+=over
+
+=item Other:
+
+B<cpeval2> S<B<--create-keys>>
+
+B<cpeval2> S<B<--updateuserdomains>>
+
+B<cpeval2> S<B<--full-help>>
+
+=back
+
+=head1 DEFINITIONS
+
+=over
+
+=item C<INPUTFILE>
+
+An input file is a text file containing cpeval2 prefixed output from "Mode 1" on both source and destination servers, concatenated into a single file.  The prefixed output begins with "s:" for the source server, and "d:" for the destination server.
+
+=back
+
+=head1 FLAGS
+
+=over
+
+=item B<--create-keys>
+
+For use only on a destination (cPanel) server.  Creates a unique SSH key-pair to be used for a dedicated migration user account on the source server, and provides copy/paste output that can be executed on the source server to create the account.  It is automatically used the first time you run cpeval2 on a cPanel server.
+
+=item B<--updateuserdomains>
+
+For use only on a third-party source (non-cPanel) server.  Downloads and executes the updateuserdomains-universal script to populate /etc/trueuserdomains.
+
+=item B<--es>
+
+For use only with "Mode 2", this provides output in Spanish.
+
+=back
+
+=head1 EXAMPLES
+
+=over
+
+=item Run cpeval2 for the first time on a source or destination server (Mode 1):
+
+B<cpeval2>
+
+=item Run cpeval2 after "Mode 1" prefixed output from both servers has been copied into "cpeval2-compare.txt":
+
+B<cpeval2 cpeval2-compare.txt>
+
+=item Run cpeval2 after "Mode 1" prefixed output from both servers has been copied into "cpeval2-compare.txt", and provide the output in Spanish:
+
+B<cpeval2 --es cpeval2-compare.txt>
+
+=item Download and run the updateuserdomains-universal script:
+
+B<cpeval2 --updateuserdomains>
+
+=back
+
+=head1 COPYRIGHT
+
+This software is Copyright 2015 by cPanel, Inc.
+
+THE SOFTWARE LICENSED HEREUNDER IS PROVIDED "AS IS" AND CPANEL HEREBY DISCLAIMS ALL WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, RELATING TO THE SOFTWARE, ITS THIRD PARTY COMPONENTS, AND ANY DATA ACCESSED THEREFROM, OR THE ACCURACY, TIMELINESS, COMPLETENESS, OR ADEQUACY OF THE SOFTWARE, ITS THIRD PARTY COMPONENTS, AND ANY DATA ACCESSED THEREFROM, INCLUDING THE IMPLIED WARRANTIES OF TITLE, MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  CPANEL DOES NOT WARRANT THAT THE SOFTWARE OR ITS THIRD PARTY COMPONENTS ARE ERROR-FREE OR WILL OPERATE WITHOUT INTERRUPTION.  IF THE SOFTWARE, ITS THIRD PARTY COMPONENTS, OR ANY DATA ACCESSED THEREFROM IS DEFECTIVE, YOU ASSUME THE SOLE RESPONSIBILITY FOR THE ENTIRE COST OF ALL REPAIR OR INJURY OF ANY KIND, EVEN IF CPANEL HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DEFECTS OR DAMAGES.  NO ORAL OR WRITTEN INFORMATION OR ADVICE GIVEN BY CPANEL, ITS AFFILIATES, LICENSEES, DEALERS, SUB-LICENSORS, AGENTS OR EMPLOYEES SHALL CREATE A WARRANTY OR IN ANY WAY.
+
 =cut
---------------------------------------------------------------------------------------
-        How to add checks to cpeval2
---------------------------------------------------------------------------------------
+END_POD
 
-There are 4 things that need to be done. Using the PHP check as an example:
+# ADDING CHECKS
+# There are 4 things that need to be done. Using the PHP check as an example:
 
-When run WITHOUT an input file (e.g., lwp-request x.x.x.x/cpeval2 | perl):
+# When run WITHOUT an input file (e.g., lwp-request x.x.x.x/cpeval2 | perl):
 
-    (1) print_php_info()            # prints PHP: 5.3.24
-    (2) print_prefixed_php_info()   # prints s:Ensim:PHP:5.1
+    # (1) print_php_info()            # prints PHP: 5.3.24
+    # (2) print_prefixed_php_info()   # prints s:Ensim:PHP:5.1
 
 
-When run WITH an input file (e.g., ./cpeval2 outfile):
+# When run WITH an input file (e.g., ./cpeval2 outfile):
 
-    (3) parse_output_file()
-    (4) print_parsed_php_info( $src_php, $dst_php )
+    # (3) parse_output_file()
+    # (4) print_parsed_php_info( $src_php, $dst_php )
 
-=cut
+
 
 use strict;
 use warnings;
+use Getopt::Long;
 use IPC::Open3;
 use IO::Socket::INET;
-use Getopt::Long;
+use Pod::Usage;
 use POSIX qw( strftime );
 use Term::ANSIColor qw(:constants);
 $Term::ANSIColor::AUTORESET = 1;
 
-my $version = '1.30';
+my $version = '1.31';
 
-my %opts = (
-    'create-keys' => 0,
-    'create-user' => 0,
-    'cpticket'    => undef,
-    'cpmiguser'   => undef,
-    'cpmigkey'    => undef
-);
+my $opts = opts_get();
 
-Getopt::Long::GetOptions(
-    'create-keys'   => \$opts{'create_keys'},
-    'create-user'   => \$opts{'create_user'},
-    'cpmigticket=i' => \$opts{'cpmigticket'},
-    'cpmiguser=s'   => \$opts{'cpmiguser'},
-    'cpmigkey=s'    => \$opts{'cpmigkey'}
-);
+create_cpmig_user() if $opts->{'createuser'};
 
-create_cpmig_user() if $opts{'create_user'};
-
-if ( @ARGV > 2 ) { 
-    print "  Usage is one of the following:\n\n";
-    print "[root\@host ~]# $0\n";
-    print "[root\@host ~]# $0 --create-keys\n";
-    print "[root\@host ~]# $0 <infile>\n";
-    print "[root\@host ~]# $0 <infile> --es\n";
-    exit;
-}
+my $DEBUG              = 0;
 
 my $panel_regex = 's:(?:Plesk(?:8|9|10|10SMB|11|12)|Ensim|DirectAdmin)';
-
-my $es = 0;                 # for use with an input file so that we can print ES back to the customer
-if ( $ARGV[1] and $ARGV[1] eq '--es' ) { $es = 1; }
-
-my $infile = shift;         # input file which contains the output from standalone mode for src and dst servers
 
 my $prefix;                 # d: or s:Plesk9 or s:DirectAdmin, etc.
 my $apache_bin;
@@ -94,26 +169,24 @@ my ( $plesk_major_version, $plesk_minor_version );
 my @badusers;               # if mysql username conflicts are detected, skip any bad users since they need renaming anyway
 
 get_control_panel_and_set_prefix();
-check_for_empty_trueuserdomains();
 verify_mysql_connectivity();
 
 my $ticket = get_ticket();
 my $cpmiguser = 'cpmig' . $ticket;
 
-if ($opts{'create_keys'}) {
+if ($opts->{'createkeys'}) {
     die "create-keys should only be run on the cPanel destination host.\n" unless $is_cpanel;
     create_cpmig_keypair($cpmiguser, $ticket);
     exit;
 }
 
-## behave like the original cpeval
-if ( !$infile ) {
-    if ( ! -f '/etc/trueuserdomains' or ! -f '/etc/domainips' ) { 
-        print "/etc/trueuserdomains OR /etc/domainips missing!\n";
-        print "Use 'Fetch Accounts List' to generate them.\n";
-        exit;
-    }
+if ($opts->{'updateuserdomains'}) {
+    die "cpeval2 --updateuserdomains is only for non-cPanel servers.\nUse /scripts/updateuserdomains instead.\n" if $is_cpanel;
+}
 
+## behave like the original cpeval
+if ( !$opts->{'inputfile'} ) {
+    check_trueuserdomains();
     print_control_panel_info();
     print_os_info();
     print_perl_info();
@@ -157,10 +230,10 @@ if ( !$infile ) {
 }
 ## parse output file; this prints info we can just copy/paste into the ticket
 else {
-    parse_output_file( $infile );
+    parse_output_file( $opts->{'inputfile'} );
 }
 
-unless ( $infile ) {
+unless ( $opts->{'inputfile'} ) {
     print_header('DISK SPACE');
     print "Please review this output now, compare with the output from the other server, and check for possible issues:\n\n";
     print `df -Ph | column -t | head -1 ; df -Ph | column -t | sort | uniq | egrep -v '^Filesystem|/var/named/run-root/var/run/dbus|/var/named/chroot|/usr/local/psa/handlers/|/virtfs/| /tmp\$'`;
@@ -190,7 +263,7 @@ if ( $is_cpanel == 1 ) {
     check_for_dns_clustering();
 }
 
-unless ( $infile ) {
+unless ( $opts->{'inputfile'} ) {
     if ( $is_cpanel == 1 ) {
         my $mailutil_missing_libs = 0; 
 
@@ -220,7 +293,7 @@ submit_stats_info();
 
 check_for_missing_scp();
 
-auto_create_keypair($cpmiguser, $ticket) unless $infile;
+auto_create_keypair($cpmiguser, $ticket) unless $opts->{'inputfile'};
 
 ##########
 
@@ -367,12 +440,44 @@ sub get_control_panel_and_set_prefix {
     print_news_da()     if ( $is_da == 1 );
 }
 
-sub check_for_empty_trueuserdomains {
+sub check_trueuserdomains {
+    my $tud = '/etc/trueuserdomains';
+    my $dip = '/etc/domainips';
+    my $uudu = 'http://httpupdate.cpanel.net/cpanelsync/transfers_PUBLIC/pkgacct/updateuserdomains-universal';
+    my $max_age = 30; #minutes
+    my $skip_update = 0;
+
     if ( $is_cpanel == 0 ) {
-        if ( -f '/etc/trueuserdomains' and -z '/etc/trueuserdomains' ) {
-            die "/etc/trueuserdomains exists, but is empty!";
+        if ( -f $tud ) {
+            my $age = int((time() - (stat(_))[9]) / 60);
+            die("${tud} exists, but unable to determine modification time!\n\n") unless defined($age);
+            if ( ! $opts->{'updateuserdomains'} and $age <= $max_age ){
+                print "\n${tud} is less than ${max_age} minutes old, not auto-updating.\n";
+                print "Use cpeval2 --updateuserdomains to force an update.\n";
+                $skip_update = 1;
+            }
+        }
+        if ( $opts->{'updateuserdomains'} or ! $skip_update ) {
+            print "${tud} doesn't exist, is more than ${max_age} minutes old, or you forced an update.\n";
+            print "\nDownloading and running updateuserdomains-universal via curl...\n";
+            if ( system( 'curl -s ' . $uudu . ' | perl' ) != 0 ) {
+                print "\nDownloading and running updateuserdomains-universal via wget...\n";
+                if ( system( 'wget -q -O - ' . $uudu . ' | perl' ) != 0 ) {
+                    print "\nFailed to download and run updateuserdomains-universal!\n";
+                    sleep 2;
+                }
+            }
+        }
+        if ( -f $tud and -z _ ) {
+            die "\n${tud} exists, but is empty!\n\n";
         }
     }
+  
+   if ( ! -f $tud or ! -f $dip ) { 
+        die "\n${tud} OR ${dip} missing!\nUse updateuserdomains to generate them.\n\n";
+    }
+
+    print "\n";
 }
 
 sub check_destination_var_usage {
@@ -1108,51 +1213,60 @@ sub get_psql_auth {
 sub print_custom_apache_modules {
     my @custom;
 
-    # Base installed Apache Modules through EasyApache from a fresh cPanel install as reported by "httpd -l"
-    # Last reviewed: 09/19/2013
-    # Cpanel::Easy::Apache v3.22.10 rev9999
+    # Last reviewed: 08/20/2015
+    # Cpanel::Easy::Apache v3.30.0 rev9999
+    # EasyApache Basic Profile module list from 'httpd -l' for Apache 2.2 and 2.4 combined
     my @base = qw(
         core.c
-        mod_authn_file.c
-        mod_authn_default.c
-        mod_authz_host.c
-        mod_authz_groupfile.c
-        mod_authz_user.c
-        mod_authz_default.c
+        http_core.c
+        mod_access_compat.c
+        mod_actions.c
+        mod_alias.c
+        mod_asis.c
         mod_auth_basic.c
-        mod_include.c
-        mod_filter.c
-        mod_log_config.c
-        mod_logio.c
+        mod_authn_core.c
+        mod_authn_default.c
+        mod_authn_file.c
+        mod_authz_core.c
+        mod_authz_default.c
+        mod_authz_groupfile.c
+        mod_authz_host.c
+        mod_authz_user.c
+        mod_autoindex.c
+        mod_cgi.c
+        mod_deflate.c
+        mod_dir.c
         mod_env.c
         mod_expires.c
+        mod_filter.c
         mod_headers.c
-        mod_setenvif.c
-        mod_version.c
+        mod_include.c
+        mod_info.c
+        mod_log_config.c
+        mod_logio.c
+        mod_mime.c
+        mod_negotiation.c
+        mod_proxy_ajp.c
+        mod_proxy_balancer.c
         mod_proxy.c
         mod_proxy_connect.c
         mod_proxy_ftp.c
         mod_proxy_http.c
         mod_proxy_scgi.c
-        mod_proxy_ajp.c
-        mod_proxy_balancer.c
-        mod_ssl.c
-        prefork.c
-        http_core.c
-        mod_mime.c
-        mod_status.c
-        mod_autoindex.c
-        mod_asis.c
-        mod_info.c
-        mod_suexec.c
-        mod_cgi.c
-        mod_negotiation.c
-        mod_dir.c
-        mod_actions.c
-        mod_userdir.c
-        mod_alias.c
         mod_rewrite.c
+        mod_setenvif.c
+        mod_slotmem_shm.c
         mod_so.c
+        mod_socache_dbm.c
+        mod_socache_shmcb.c
+        mod_ssl.c
+        mod_status.c
+        mod_suexec.c
+        mod_unique_id.c
+        mod_unixd.c
+        mod_userdir.c
+        mod_version.c
+        prefork.c
     );
 
     my $apachem = `$apache_bin -l 2> /dev/null`;
@@ -1171,7 +1285,7 @@ sub print_custom_apache_modules {
         push( @custom, " -None-\n" );
     }   
 
-    print "\nCustom Apache Modules:\n";
+    print "\nNon-default Apache Modules:\n";
     for my $module ( @custom ) {
         chomp $module;
         print "$module\n";
@@ -1181,9 +1295,9 @@ sub print_custom_apache_modules {
 sub print_custom_php_modules {
     my @custom;
 
-    # Base installed PHP Modules through EasyApache from a fresh cPanel install as reported by "php -m"
-    # Last updated: 09/19/2013
-    # Cpanel::Easy::Apache v3.22.10 rev9999
+    # Last reviewed: 08/20/2015
+    # Cpanel::Easy::Apache v3.30.0 rev9999
+    # EasyApache Basic Profile module list from 'php -m' for PHP 5.4
     my @base = qw(
         bcmath
         calendar
@@ -1195,14 +1309,20 @@ sub print_custom_php_modules {
         ereg
         filter
         ftp
+        gd
         hash
         iconv
         imap
         json
         libxml
+        mcrypt
         mysql
+        mysqlnd
         openssl
         pcre
+        PDO
+        pdo_mysql
+        pdo_sqlite
         Phar
         posix
         Reflection
@@ -1221,15 +1341,15 @@ sub print_custom_php_modules {
 
     # Modules that EasyApache does not support
     my @ignore = qw(
-        sysvmsg
-        sysvsem
-        sysvshm
         dbase
         gmp
         ldap
         pcntl
         readline
         shmop
+        sysvmsg
+        sysvsem
+        sysvshm
     );
 
     # tack them onto @mods so they're disregarded
@@ -1248,19 +1368,9 @@ sub print_custom_php_modules {
         @custom = sort @custom;
     }
 
-    ## TTF (FreeType) check
-    my $freetype = `php -i 2>/dev/null | grep -i 'freetype support => enabled'`;
-    if ($freetype) {
-        push @custom, ' TTF (FreeType)';
-    }
-
     return if !@custom;
 
-    if ( !@custom ) { 
-        push( @custom, " -None-\n" );
-    }
-
-    print "\nCustom PHP Modules:\n";
+    print "\nNon-default PHP Modules:\n";
     for my $module ( @custom ) {
         chomp $module;
         print "$module\n";
@@ -1950,7 +2060,7 @@ sub parse_output_file {
     my $src_disk_usage_ref = \@src_disk_usage;
     my $dst_disk_usage_ref = \@dst_disk_usage;
 
-    if ( $es == 1 ) {
+    if ( $opts->{'es'} == 1 ) {
         print "Hola,\n\nLa evaluación inicial ha completado. Nuestros resultados son los siguientes:\n\n";
     }
     else {
@@ -1983,7 +2093,7 @@ sub parse_output_file {
 }
 
 sub print_parsed_panel_info {
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print "Source: " . $src_panel_version . "\n";
         print "Destination: " . $dst_panel_version . "\n";
     }
@@ -1995,7 +2105,7 @@ sub print_parsed_panel_info {
 
 sub print_parsed_eula_info {
     if ( $eula_accepted == 0 ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('cPanel End User License Agreement');
             print q{The license agreement has not yet been accepted. Before we can proceed, you must log into WHM as root and accept the license agreement, then complete the initial setup that follows.
 };
@@ -2047,7 +2157,7 @@ sub print_parsed_php_info {
     ## if src php is higher than 5
     if ( $src_php_major > 5 ) {
         $print_message = 1;
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             $addendum = qq{
 cPanel only supports PHP 5 at this time. Since we cannot change the version of PHP to match that of the $src_panel_noversion server, this message is informational only. No action is required on your part.
             };
@@ -2061,7 +2171,7 @@ En estos momentos cPanel sólo es compatible con PHP 5. Debido a esto no podremo
     ## if src php is lower than 5
     elsif ( $src_php_major < 5 or ( $src_php_major == 5 and $src_php_minor < $min_php_minor_supported )) {
         $print_message = 1;
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             $addendum = qq{
 The versions of PHP do not match. cPanel currently supports PHP 5.3, 5.4, and 5.5. Unfortunately, due to the end-of-life PHP version on the $src_panel_noversion server[1], there may be issues with your sites displaying correctly on the cPanel server. Many features available in PHP <= 5.2 were deprecated in PHP 5.3 and later removed in PHP 5.4 entirely[2].
 
@@ -2093,7 +2203,7 @@ Además, después de la migración, no podemos proporcionar asistencia con probl
     ## if cPanel isn't using PHP 5 for some reason
     if ( $dst_php_major != 5 ) {
         $print_message = 1;
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             $addendum = qq{
 cPanel only supports PHP 5 at this time. If you have elected to have us recompile PHP to add support for certain PHP modules, we will be unable to do so unless we can install PHP 5. We currently support PHP $supported_php_versions.
 
@@ -2116,7 +2226,7 @@ En estos momentos cPanel sólo es compatible con PHP 5. Si usted ha optado que n
     }
 
     if ( $print_message == 1 ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('PHP Versions');
         }
         else { #ES
@@ -2138,7 +2248,7 @@ sub print_parsed_mysql_info {
         $src_mysql =~ s/:UNSUPPORTED//g;
 
         $print_message = 1;
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             $addendum = qq{
 The $src_panel_noversion server is running MySQL ${src_mysql}. This version is not supported at this time. We can attempt the migration anyway, but you may need to create the databases on the cPanel server, then manually export and import your databases.
 
@@ -2159,7 +2269,7 @@ The cPanel server is running MySQL 4, which is not supported at this time. Our r
     }
 
     if ( $print_message == 1 ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('MySQL Versions');
         }
         else { #ES
@@ -2185,7 +2295,7 @@ sub print_parsed_bad_username_info {
     
     # get panel version. print how to change username based on panel version
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('Incompatible Usernames');
         print qq{
 Usernames were found on the $src_panel_noversion server that are not compatible with cPanel servers. You will need to rename those users before we can copy them. A list of these users is as follows:
@@ -2204,7 +2314,7 @@ USERNAME: DOMAIN
         print "${domain}: $badusers{$domain}\n";
     }
  
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_username_change_info();
     }
     else {
@@ -2215,7 +2325,7 @@ USERNAME: DOMAIN
 sub print_parsed_bad_user_config_info {
     my %baduserconfig = @_;
     return if ! %baduserconfig;
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('User configuration issues');
         print qq{
 Some user configuration problems were found on the $src_panel_noversion server that may cause failues during the transfer process.  You will need to correct these configuration issues before we can copy these users.  A list of these users and configuration problems is as follows:
@@ -2241,7 +2351,7 @@ USUARIO: DESCRIPCION
     );
     for my $user ( sort keys %baduserconfig ) {
         for my $type ( sort keys %{$baduserconfig{$user}} ) {
-            my $type_lang = $type . ( $es ? "_ES" : "_EN" );
+            my $type_lang = $type . ( $opts->{'es'} ? "_ES" : "_EN" );
             print $user . ": " . $problem{$type_lang} . $baduserconfig{$user}{$type} . "\n\n";
         }
     }
@@ -2249,7 +2359,7 @@ USUARIO: DESCRIPCION
 
 sub print_reseller_username_change_info {
     # This has only been tested on Plesk 10, 11, and 11.5.
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print q{
 1. Log into Plesk as admin
 2. Click "Resellers"
@@ -2416,7 +2526,7 @@ sub print_parsed_ipaddr_info {
     my ( $src_dedicated_ipaddrs_used, $dst_ipaddrs_free, @sites_on_dedicated_ipaddrs ) = @_;
 
     if ( $src_dedicated_ipaddrs_used > $dst_ipaddrs_free ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('IP Addresses');
             print qq{
 On the $src_panel_noversion server, the following sites are on dedicated IP addresses:
@@ -2434,7 +2544,7 @@ On the $src_panel_noversion server, the following sites are on dedicated IP addr
             print "* $site\n";
         }
 
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print qq{
 
 However, the cPanel server has $dst_ipaddrs_free dedicated IP address(es) available.
@@ -2474,7 +2584,7 @@ sub print_parsed_forwarding_domain_info {
 
     return if !%forwarding_domains;
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('Forwarding Domains');
 
         print q{
@@ -2495,7 +2605,7 @@ Usted puede añadirlos en WHM >> Setup/Edit Domain Forwarding (esto requiere só
 
     print "\n";
     for my $domain ( sort keys %forwarding_domains ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print "${domain}: forwarded to -> $forwarding_domains{$domain}\n";
         }
         else { #ES
@@ -2508,7 +2618,7 @@ sub print_parsed_nohosting_domain_info {
     my @nohosting_domains = @_;
     return if !@nohosting_domains;
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('No Hosting domains');
 
         print q{
@@ -2540,7 +2650,7 @@ sub print_parsed_tomcat_info {
     if ( $src_tomcat and !$dst_tomcat ) {
         print_header('Tomcat');
 
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print qq{
 
 Tomcat is installed on the $src_panel server, but not on the cPanel server.
@@ -2571,7 +2681,7 @@ sub print_parsed_coldfusion_info {
     if ( $src_coldfusion and !$dst_coldfusion ) {
         print_header('ColdFusion');
 
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print qq{
 
 ColdFusion appears to be running on the $src_panel server, but not on the cPanel server.
@@ -2603,7 +2713,7 @@ sub print_parsed_reseller_username_conflicts {
 
     @reseller_username_conflicts = sort @reseller_username_conflicts;
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('Reseller Username Conflicts');
 
         print qq{
@@ -2637,7 +2747,7 @@ sub print_parsed_mysql_openfileslimit {
     if ( $open_files_limit < 10_000 ) {
         print_header('MySQL open_files_limit');
 
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print qq{
 On the cPanel server, MySQL's open_files_limit is set to $open_files_limit which may be lower
 than what is necessary to successfully copy databases. I recommend increasing this to 10000
@@ -2667,7 +2777,7 @@ sub print_parsed_mysql_skip_networking {
 
     print_header('MySQL skip-networking');
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print qq{
 On the cPanel server, MySQL's skip-networking option is enabled. This can prevent databases
 from restoring properly. This option needs to be disabled throughout the migration process.
@@ -2695,7 +2805,7 @@ sub print_parsed_mysql_old_style_passwords_info {
     $cpanel_mysql_version = substr $cpanel_mysql_version, 0, 2;
 
     if ( defined $mysql_old_style_passwords == 1 and $cpanel_mysql_version >= 56 ) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('MySQL 5.6 and old-passwords=1');
             print qq{
 The ${src_panel_noversion} server is using the "old-passwords=1" option. However, the cPanel server
@@ -2792,7 +2902,7 @@ output_buffering:
     }
 
     if ($addendum) {
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print_header('php.ini Settings');
             print qq{
 We have checked several of the most commonly customized configuration options in php.ini and found some differences.
@@ -2932,7 +3042,7 @@ sub check_for_ssl_certificates {
 sub check_for_dns_clustering {
     return if !-e '/var/cpanel/useclusteringdns';
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('DNS CLUSTERING (for libkeyutils migrations)');
         print qq{
 The following cluster members were found to be configured on this server
@@ -3042,7 +3152,7 @@ that would not be copied. Things to keep in mind are:
 sub print_parsed_mysql_username_conflicts {
     my @mysql_username_conflicts = @_;
     my $count = 1;
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_header('mysql Username Conflicts');
         print qq{
 mysql username conflicts have been found. To fix, please rename the user(s) specified below:
@@ -3057,7 +3167,7 @@ mysql username conflicts have been found. To fix, please rename the user(s) spec
     for my $conflict (@mysql_username_conflicts) {
         my ( $domain1, $user, $domain2 ) = split /:/, $conflict;
         # subscription1.test has mysql user "example", but there is a Plesk account named example, owned by example.com
-        if ( $es == 0 ) {
+        if ( $opts->{'es'} == 0 ) {
             print "[CONFLICT $count] $domain1 has mysql user \"$user\" (to fix, rename ${domain2}'s \"$user\")\n";
         }
         else { #ES
@@ -3066,7 +3176,7 @@ mysql username conflicts have been found. To fix, please rename the user(s) spec
         $count++;
     }
 
-    if ( $es == 0 ) {
+    if ( $opts->{'es'} == 0 ) {
         print_username_change_info();
     }
     else {
@@ -3159,6 +3269,7 @@ sub submit_stats_info {
 }
 
 sub get_ticket {
+    return $opts->{'cpmigticket'} if defined($opts->{'cpmigticket'});
     my $ticket;
     if ( exists $ENV{HISTFILE} && $ENV{HISTFILE} =~ /ticket.(\d{7,10})$/ ) {
         $ticket = $1;
@@ -3273,7 +3384,7 @@ sub create_cpmig_user {
 
     my $fail = 0;
     foreach my $test ( qw( cpmigticket cpmiguser cpmigkey ) ) {
-        if ( ! exists($opts{$test}) || ( exists($opts{$test}) && ! $opts{$test} ) ) {
+        if ( ! exists($opts->{$test}) || ( exists($opts->{$test}) && ! $opts->{$test} ) ) {
             print "-- Missing " . $test . "\n";
             $fail = 1;
         }
@@ -3281,9 +3392,9 @@ sub create_cpmig_user {
 
     die if $fail;
 
-    my $user = $opts{'cpmiguser'};
-    my $ticket = $opts{'cpmigticket'};
-    my $pubkey = $opts{'cpmigkey'};
+    my $user = $opts->{'cpmiguser'};
+    my $ticket = $opts->{'cpmigticket'};
+    my $pubkey = $opts->{'cpmigkey'};
     my $password;
     my $expire;
     my @user_pwent;
@@ -3440,4 +3551,57 @@ sub create_cpmig_user {
     }
 
 exit 0;
+}
+
+sub opts_get {
+    my $badopt = 0;
+    my %opts = (
+        'createkeys'        => 0,
+        'createuser'        => 0,
+        'cpmigticket'       => undef,
+        'cpmiguser'         => undef,
+        'cpmigkey'          => undef,
+        'es'                => 0,
+        'help'              => 0,
+        'inputfile'         => undef,
+        'full-help'         => 0,
+        'updateuserdomains' => 0
+    );
+
+    Getopt::Long::GetOptions(
+        'create-keys|createkeys'    => \$opts{'createkeys'},
+        'create-user|createuser'    => \$opts{'createuser'},
+        'cpmigticket=i'             => \$opts{'cpmigticket'},
+        'cpmiguser=s'               => \$opts{'cpmiguser'},
+        'cpmigkey=s'                => \$opts{'cpmigkey'},
+        'debug'                     => \$DEBUG,
+        'es'                        => \$opts{'es'},
+        'full-help|fullhelp'        => \$opts{'full-help'},
+        'inputfile=s'               => \$opts{'inputfile'},
+        'updateuserdomains'         => \$opts{'updateuserdomains'},
+        'usage|help|h'              => \$opts{'help'}
+    ) or $badopt = 1;
+
+
+    $opts{'inputfile'} = shift @ARGV unless defined($opts{'inputfile'});
+
+    open my $pod_fh, '<', \$pod_data;
+
+    pod2usage( { -exitval => 1, -verbose => 1, -input => $pod_fh } ) if $opts{'help'};
+    pod2usage( { -exitval => 1, -verbose => 2, -input => $pod_fh } ) if $opts{'full-help'};
+    pod2usage( { -exitval => 2, -verbose => 1, -input => $pod_fh } ) if $badopt;
+
+    if ( @ARGV > 1 ) {
+        print STDERR "Too many input file names specified on command line.\n";
+        pod2usage( { -exitval => 2, -verbose => 1, -input => $pod_fh } );
+    }
+
+    if ( defined($opts{'inputfile'}) && ! -f $opts{'inputfile'} ) {
+        print STDERR "Input file does not exist.\n";
+        pod2usage( { -exitval => 2, -verbose => 1, -input => $pod_fh } );
+    }
+
+    close $pod_fh;
+    
+    return \%opts;
 }


### PR DESCRIPTION
UPDATED - Fully convert handling of command-line options to Getopt::Long
UPDATED - Apache module list from both 2.2 and 2.4 Basic EA profiles, which should reduce the list of reported "custom" Apache modules.
UPDATED - PHP module list from Basic EA profile build with PHP 5.4, which should reduce the list of reported "custom" PHP modules.
UPDATED - Renamed "Custom (Apache|PHP) Modules" to "Non-default (Apache|PHP) Modules" to more accurately reflect what is being reported.
REMOVED - "TTF (FreeType)" PHP module from custom module check, this is included in the default PHP profile.
ADDED - Integrated help documentation, run it with --help for a quick synopsis or --full-help for the whole doc.

ADDED - Copyright notice.
ADDED - Automatic download and execution of updateuserdomains-universal if /etc/trueuserdomains does not exist or is > 30 minutes old.
